### PR TITLE
added org.osgi.core and org.osgi.compendium

### DIFF
--- a/dist/pom-5.6.1.xml
+++ b/dist/pom-5.6.1.xml
@@ -2261,6 +2261,18 @@
                 <version>2.5.1-R1487419</version>
                 <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.core</artifactId>
+                <version>4.2.0</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.compendium</artifactId>
+                <version>4.2.0</version>
+                <scope>provided</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Added org.osgi.core and org.osgi.compendium to pom-5.6.1.xml (they exist in 5.6.0, probably an oversight)